### PR TITLE
fix: icinga_agent_enable_features is wronly converted to a list in task

### DIFF
--- a/roles/icinga_agent/tasks/main.yml
+++ b/roles/icinga_agent/tasks/main.yml
@@ -71,8 +71,7 @@
     src: ../features-available/{{ item }}
     dest: /etc/icinga2/features-enabled/{{ item }}
     state: link
-  loop:
-    - "{{ icinga_agent_enable_features }}"
+  loop: "{{ icinga_agent_enable_features }}"
   when:
     - icinga_agent_enable_features is defined
     - icinga_agent_enable_features | length > 0


### PR DESCRIPTION
`icinga_agent_enable_features` is already an list, so the loop always had only one item with the original `icinga_agent_enable_features` list in it.