### PR TITLE
Make hostname for Icinga agent configurable

### DIFF
--- a/roles/icinga_agent/README.md
+++ b/roles/icinga_agent/README.md
@@ -8,9 +8,10 @@ This role installs and configures the icinga agent.
 | icinga_agent_package | yes | icinga2 | installs icinga2 package
 | icinga_agent_registration | yes | false | used to register your installed icinga agent against your icinga master
 | icinga_agent_enable_features | no | | config files for extra features you can use along with icinga. If you add for example api.conf to the variable the feature will be active in your icinga instance
-| icinga_agent_ca_host | no | | your master intance (f.e: master0-example.de)
+| icinga_agent_ca_host | no | | your master instance (f.e: master0-example.de)
 | icinga_agent_ca_host_icinga_port | no | 5665 | Icinga agent port
 | icinga_agent_salt | no | | used to hash password
+| icinga_agent_hostname | no | "{{ ansible_hostname }}" | define hostname (use `ansible_fqdn` for icinga satellites)
 | icinga_agent_custom_features_template_path | no | | define custom feature file (f.e. {{ playbook_dir }}/icinga_custom_templates/*)
 | icinga_agent_constants[RedHat, Debian] | yes | const PluginDir = "/usr/lib64/nagios/plugins"<br> const PluginContribDir = "/usr/lib64/nagios/plugins"<br> const ManubulonPluginDir = "/usr/lib64/nagios/plugins"<br> const ZoneName = "{{ ansible_hostname }}"<br> const NodeName = "{{ ansible_hostname }}"<br> const TicketSalt = "" | define content for config file constants.conf, depending on the OS family |
 | icinga_agent_api_conf | yes | accept_config = true<br>accept_commands = true | define content for feature file api.conf |

--- a/roles/icinga_agent/README.md
+++ b/roles/icinga_agent/README.md
@@ -11,7 +11,7 @@ This role installs and configures the icinga agent.
 | icinga_agent_ca_host | no | | your master instance (f.e: master0-example.de)
 | icinga_agent_ca_host_icinga_port | no | 5665 | Icinga agent port
 | icinga_agent_salt | no | | used to hash password
-| icinga_agent_hostname | no | "{{ ansible_hostname }}" | define hostname (use `ansible_fqdn` for icinga satellites)
+| icinga_agent_hostname | no | "{{ ansible_hostname }}" | define hostname (icinga satellites require this to be set to `ansible_fqdn` or some other usable FQDN)
 | icinga_agent_custom_features_template_path | no | | define custom feature file (f.e. {{ playbook_dir }}/icinga_custom_templates/*)
 | icinga_agent_constants[RedHat, Debian] | yes | const PluginDir = "/usr/lib64/nagios/plugins"<br> const PluginContribDir = "/usr/lib64/nagios/plugins"<br> const ManubulonPluginDir = "/usr/lib64/nagios/plugins"<br> const ZoneName = "{{ ansible_hostname }}"<br> const NodeName = "{{ ansible_hostname }}"<br> const TicketSalt = "" | define content for config file constants.conf, depending on the OS family |
 | icinga_agent_api_conf | yes | accept_config = true<br>accept_commands = true | define content for feature file api.conf |

--- a/roles/icinga_agent/defaults/main.yml
+++ b/roles/icinga_agent/defaults/main.yml
@@ -2,20 +2,21 @@
 icinga_agent_package: icinga2
 icinga_agent_registration: false
 icinga_agent_ca_host_icinga_port: 5665
+icinga_agent_hostname: "{{ ansible_hostname }}"
 icinga_agent_constants:
   RedHat: |
     const PluginDir = "/usr/lib64/nagios/plugins"
     const PluginContribDir = "/usr/lib64/nagios/plugins"
     const ManubulonPluginDir = "/usr/lib64/nagios/plugins"
-    const ZoneName = "{{ ansible_hostname }}"
-    const NodeName = "{{ ansible_hostname }}"
+    const ZoneName = "{{ icinga_agent_hostname }}"
+    const NodeName = "{{ icinga_agent_hostname }}"
     const TicketSalt = ""
   Debian: |
     const PluginDir = "/usr/lib/nagios/plugins"
     const PluginContribDir = "/usr/lib/nagios/plugins"
     const ManubulonPluginDir = "/usr/lib/nagios/plugins"
-    const ZoneName = "{{ ansible_hostname }}"
-    const NodeName = "{{ ansible_hostname }}"
+    const ZoneName = "{{ icinga_agent_hostname }}"
+    const NodeName = "{{ icinga_agent_hostname }}"
     const TicketSalt = ""
 icinga_agent_api_conf: |
   accept_config = true

--- a/roles/icinga_agent/tasks/main.yml
+++ b/roles/icinga_agent/tasks/main.yml
@@ -93,7 +93,7 @@
 
     - name: Generate ticket and save it as a variable
       ansible.builtin.command: >
-        /usr/sbin/icinga2 pki ticket --cn {{ ansible_hostname }} --salt {{ icinga_agent_salt }}
+        /usr/sbin/icinga2 pki ticket --cn {{ icinga_agent_hostname }} --salt {{ icinga_agent_salt }}
       environment:
         LD_LIBRARY_PATH: /usr/lib64
       register: ticket
@@ -102,16 +102,16 @@
 
     - name: Create certificate
       ansible.builtin.command: >
-        /usr/sbin/icinga2 pki new-cert --cn {{ ansible_hostname }}
-        --key /var/lib/icinga2/certs/{{ ansible_hostname }}.key
-        --cert /var/lib/icinga2/certs/{{ ansible_hostname }}.crt
+        /usr/sbin/icinga2 pki new-cert --cn {{ icinga_agent_hostname }}
+        --key /var/lib/icinga2/certs/{{ icinga_agent_hostname }}.key
+        --cert /var/lib/icinga2/certs/{{ icinga_agent_hostname }}.crt
       args:
-        creates: /var/lib/icinga2/certs/{{ ansible_hostname }}.crt
+        creates: /var/lib/icinga2/certs/{{ icinga_agent_hostname }}.crt
 
     - name: Save the icinga master's certificate to the host
       ansible.builtin.command: >
-        /usr/sbin/icinga2 pki save-cert --key /var/lib/icinga2/certs/{{ ansible_hostname }}.key
-        --cert /var/lib/icinga2/certs/{{ ansible_hostname }}.crt
+        /usr/sbin/icinga2 pki save-cert --key /var/lib/icinga2/certs/{{ icinga_agent_hostname }}.key
+        --cert /var/lib/icinga2/certs/{{ icinga_agent_hostname }}.crt
         --trustedcert /var/lib/icinga2/certs/trusted-master.crt
         --host {{ icinga_agent_ca_host }}
       args:
@@ -121,8 +121,8 @@
       ansible.builtin.command: >
         /usr/sbin/icinga2 pki request --host {{ icinga_agent_ca_host }}
         --port {{ icinga_agent_ca_host_icinga_port }}
-        --ticket {{ ticket.stdout }} --key /var/lib/icinga2/certs/{{ ansible_hostname }}.key
-        --cert /var/lib/icinga2/certs/{{ ansible_hostname }}.crt
+        --ticket {{ ticket.stdout }} --key /var/lib/icinga2/certs/{{ icinga_agent_hostname }}.key
+        --cert /var/lib/icinga2/certs/{{ icinga_agent_hostname }}.crt
         --trustedcert /var/lib/icinga2/certs/trusted-master.crt --ca /var/lib/icinga2/certs/ca.crt
       args:
         creates: /var/lib/icinga2/certs/ca.crt


### PR DESCRIPTION
Added 'icinga_agent_hostname' to be able to use FQDNs, which is considered a convention by icinga:

_By convention all nodes should be configured using their FQDN._
https://icinga.com/docs/icinga-2/latest/doc/06-distributed-monitoring/#conventions
