### PR TITLE
add git config step to fix "dubious ownership" error in git step

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,8 @@ authors:
   - Christopher Grau <c.grau@telekom.de>
   - Daniel Uhlmann <daniel.uhlmann@telekom.de>
 description: >-
-  This collection acts as a 'meta collection' for roles and collections aimed at managing components of Icinga. It also handles Icinga agent installation and custom check rollout.
+  This collection acts as a 'meta collection' for roles and collections aimed at managing components of Icinga.
+  It also handles Icinga agent installation and custom check rollout.
 dependencies:
   telekom_mms.icinga_director: "*"
   telekom_mms.icinga_business_process: "*"

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,3 +2,5 @@
 collections:
   - name: telekom_mms.icinga_director
     version: 2.1.0
+  - name: community.general
+    version: 9.3.0

--- a/roles/icinga_plugins/tasks/main.yml
+++ b/roles/icinga_plugins/tasks/main.yml
@@ -46,6 +46,13 @@
     - icinga_plugins_path is defined
     - icinga_plugins_path | length > 0
 
+- name: Set icinga plugins directory as safe path
+  community.general.git_config:
+    name: safe.directory
+    scope: global
+    add_mode: add
+    value: "{{ icinga_plugins_git_repo_dest_path }}"
+
 - name: Copy icinga plugins to destination path from git repo
   ansible.builtin.git:
     repo: "{{ icinga_plugins_git_repo_url }}"


### PR DESCRIPTION
the permission of the checks in the git repository got changed by the file step causing the "dubios ownership" error in the git step on subsequent runs of the role.