### PR TITLE
Update versions in GitHub workflow

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -12,3 +12,5 @@ offline: false
 warn_list:
   - var-naming[no-role-prefix]
   - args[module]
+  - fqcn[action-core]
+  - meta-runtime[unsupported-version]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ on:
       - 'tests/**'
       - 'meta/**'
       - 'galaxy.yml'
+      - '.github/workflows/CI.yml'
   pull_request:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - 'tests/**'
       - 'meta/**'
       - 'galaxy.yml'
+      - '.github/workflows/CI.yml'
   # Run CI once per week (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still
   # testing against latest version of ansible-test for each ansible-core

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,9 +38,10 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.15
-          - stable-2.16
           - stable-2.17
+          - stable-2.18
+          - stable-2.19
+          - devel
     runs-on: ubuntu-latest
 
     steps:
@@ -52,7 +53,7 @@ jobs:
       - name: Set up Python ${{ matrix.ansible }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: python -m pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -68,13 +69,11 @@ jobs:
       fail-fast: false
       matrix:
         ansible:
-          - stable-2.15
-          - stable-2.16
           - stable-2.17
+          - stable-2.18
+          - stable-2.19
           - devel
         python:
-          - "3.9"
-          - "3.10"
           - "3.11"
           - "3.12"
     services:
@@ -105,7 +104,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Run Linting
-        uses: ansible/ansible-lint-action@cad5176ea6f24a38f909d688bd467ec8d942d7e1 # v6.17.0
+        uses: ansible/ansible-lint@06f616d6e86e9ce4c74393318d1cbb2d016af413 # v25
 
   molecule:
     name: Molecule
@@ -117,10 +116,10 @@ jobs:
         with:
           path: ansible_collections/telekom_mms/ansible_collection_icinga
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: 3.8
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ansible
-molecule[docker]
+molecule
+molecule-plugins[docker]
 docker

--- a/roles/icinga_agent/molecule/default/molecule.yml
+++ b/roles/icinga_agent/molecule/default/molecule.yml
@@ -4,16 +4,8 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: centos7
-    image: ebesson/docker-centos7-systemd:latest
-    volumes:
-      - /sys:/sys:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-    command: ""
-  - name: rockylinux8
-    image: eniocarboni/docker-rockylinux-systemd:8
+  - name: rockylinux9
+    image: eniocarboni/docker-rockylinux-systemd:9
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/icinga_agent/molecule/default/molecule.yml
+++ b/roles/icinga_agent/molecule/default/molecule.yml
@@ -4,8 +4,8 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: rockylinux9
-    image: eniocarboni/docker-rockylinux-systemd:9
+  - name: rockylinux8
+    image: eniocarboni/docker-rockylinux-systemd:8
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/icinga_agent/molecule/default/molecule.yml
+++ b/roles/icinga_agent/molecule/default/molecule.yml
@@ -4,14 +4,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: rockylinux8
-    image: eniocarboni/docker-rockylinux-systemd:8
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-    command: ""
   - name: debian11
     image: geerlingguy/docker-debian11-ansible:latest
     cgroupns_mode: host

--- a/roles/icinga_agent/molecule/default/prepare.yml
+++ b/roles/icinga_agent/molecule/default/prepare.yml
@@ -15,9 +15,9 @@
       when: ansible_os_family == 'RedHat'
 
     - name: Install icinga2 repo
-      ansible.builtin.yum:
-        name: https://packages.icinga.com/epel/icinga-rpm-release-7-latest.noarch.rpm
-        state: present
+      ansible.builtin.get_url:
+        url: https://packages.icinga.com/centos/ICINGA-release.repo
+        dest: /etc/yum.repos.d/ICINGA-release.repo
       when: ansible_os_family == 'RedHat'
 
     - name: Install icinga2 basic packages

--- a/roles/icinga_plugins/molecule/default/molecule.yml
+++ b/roles/icinga_plugins/molecule/default/molecule.yml
@@ -4,16 +4,8 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: centos7
-    image: ebesson/docker-centos7-systemd:latest
-    volumes:
-      - /sys:/sys:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-    command: ""
-  - name: rockylinux8
-    image: eniocarboni/docker-rockylinux-systemd:8
+  - name: rockylinux9
+    image: eniocarboni/docker-rockylinux-systemd:9
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/icinga_plugins/molecule/default/molecule.yml
+++ b/roles/icinga_plugins/molecule/default/molecule.yml
@@ -4,8 +4,8 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: rockylinux9
-    image: eniocarboni/docker-rockylinux-systemd:9
+  - name: rockylinux8
+    image: eniocarboni/docker-rockylinux-systemd:8
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/roles/icinga_plugins/molecule/default/molecule.yml
+++ b/roles/icinga_plugins/molecule/default/molecule.yml
@@ -4,14 +4,6 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: rockylinux8
-    image: eniocarboni/docker-rockylinux-systemd:8
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
-    privileged: true
-    pre_build_image: true
-    command: ""
   - name: debian11
     image: geerlingguy/docker-debian11-ansible:latest
     cgroupns_mode: host

--- a/roles/icinga_plugins/molecule/default/prepare.yml
+++ b/roles/icinga_plugins/molecule/default/prepare.yml
@@ -21,20 +21,11 @@
       when: ansible_os_family == 'RedHat'
 
     - name: Install icinga2 repo
-      ansible.builtin.yum:
-        name: https://packages.icinga.com/epel/icinga-rpm-release-7-latest.noarch.rpm
-        state: present
+      ansible.builtin.get_url:
+        url: https://packages.icinga.com/centos/ICINGA-release.repo
+        dest: /etc/yum.repos.d/ICINGA-release.repo
       when:
         - ansible_facts['distribution'] == 'RedHat'
-        - ansible_facts['distribution_major_version'] == 7
-
-    - name: Install icinga2 repo
-      ansible.builtin.yum:
-        name: https://packages.icinga.com/epel/icinga-rpm-release-7-latest.noarch.rpm
-        state: present
-      when:
-        - ansible_facts['distribution'] == 'RedHat'
-        - ansible_facts['distribution_major_version'] == 8
 
     - name: Install icinga2 basic packages
       ansible.builtin.apt:


### PR DESCRIPTION
Updates used versions for out tests to the currently supportet state.
Drops some old tests, that are no longer possible to implement because of removed compatability.